### PR TITLE
fixed LazyColumn's background, (surface) color issue

### DIFF
--- a/xmaterialccp/src/main/java/com/simon/xmaterialccp/component/MaterialCodePicker.kt
+++ b/xmaterialccp/src/main/java/com/simon/xmaterialccp/component/MaterialCodePicker.kt
@@ -171,8 +171,8 @@ class MaterialCodePicker {
             ) {
                 Surface(modifier = modifier
                     .fillMaxSize()
-                    .padding(top = it.calculateTopPadding())
-                    .background(surfaceColor)){
+                    .padding(top = it.calculateTopPadding()),
+                    color = surfaceColor){
 
                     Column() {
 


### PR DESCRIPTION
Hello
Problem: I wasn't able to change backgound of lazy column
in surface we can't change background color from:
Surface( Modifier.bacground(Color.something) )

we should do something like this :
Surface( color = Color.something ){