### PR TITLE
Fix issue Crash, IllegalStateException: OffsetMapping.transformedToOriginal

### DIFF
--- a/xmaterialccp/src/main/java/com/simon/xmaterialccp/transformation/PhoneNumberTransformation.kt
+++ b/xmaterialccp/src/main/java/com/simon/xmaterialccp/transformation/PhoneNumberTransformation.kt
@@ -70,7 +70,7 @@ class PhoneNumberTransformation(countryCode: String = Locale.getDefault().countr
             } else {
                 originalToTransformed.add(index)
             }
-            transformedToOriginal.add(index - specialCharsCount)
+            transformedToOriginal.add(if (index > 0) index - specialCharsCount else index)
         }
         originalToTransformed.add(originalToTransformed.maxOrNull()?.plus(1) ?: 0)
         transformedToOriginal.add(transformedToOriginal.maxOrNull()?.plus(1) ?: 0)


### PR DESCRIPTION
When the phone format started with "(" -1 was added to the transformedToOriginal array when index was 0 and the specialCharsCount variable was 1 transformedToOriginal.add(index - specialCharsCount)