### PR TITLE
Fix: render flag as a perfect circle (no stretch)

### DIFF
--- a/xmaterialccp/src/main/java/com/simon/xmaterialccp/component/MaterialCodePicker.kt
+++ b/xmaterialccp/src/main/java/com/simon/xmaterialccp/component/MaterialCodePicker.kt
@@ -103,6 +103,7 @@ class MaterialCodePicker {
                     Image(
                         modifier = modifier
                             .width(26.dp)
+                            .aspectRatio(1f)
                             .background(shape = flagShape, color = Color.Transparent)
                             .clip(flagShape)
                             .clipToBounds(),


### PR DESCRIPTION
<table>
  <tr>
    <td align="center"><strong>master</strong></td>
    <td align="center"><strong>fix</strong></td>
  </tr>
  <tr>
    <td>
      <img
        src="https://github.com/user-attachments/assets/b12c6ee6-b0f1-42e0-a1dc-a65aae53e71d"
        alt="Screenshot master (flag oval)"
        width="320" />
    </td>
    <td>
      <img
        src="https://github.com/user-attachments/assets/ce3cfe15-313b-4635-b907-55981d7ca178"
        alt="Screenshot fix (flag circular)"
        width="320" />
    </td>
  </tr>
</table>